### PR TITLE
first pass at unbound support

### DIFF
--- a/default/eventtypes.conf
+++ b/default/eventtypes.conf
@@ -3,3 +3,6 @@ search = sourcetype=pfsense:filterlog
 
 [pfsense_openvpn_authentication]
 search = sourcetype=pfsense:openvpn action="success" OR action="failure"
+
+[pfsense_unbound]
+search = sourcetype=pfsense:unbound

--- a/default/props.conf
+++ b/default/props.conf
@@ -37,3 +37,9 @@ EXTRACT-src_ip,src_port = openvpn\[\d+\]:\s+(?<src_ip>\d+\.\d+\.\d+\.\d+):(?<src
 EXTRACT-user,reason = openvpn\[\S+\]:.*\[(?<user>\S+)\]\s+(?<reason>Peer Connection Initiated|Inactivity timeout)
 EVAL-app = "pfsense:openvpn"
 LOOKUP-openvpn_action = pfsense_openvpn_action vendor_action OUTPUTNEW action
+
+[pfsense:unbound]
+EXTRACT-queries = info: resolving (?P<dns_record>\S{2,})\s(?P<query_type>\S+)
+EXTRACT-response = info: response for (?P<dns_record>\S+)\s(?P<record_type>\S+)
+EXTRACT-reply = info: reply from\s(\S+)\s(?P<dns_server>(\d|.)+)#(?P<src_port>(\d+))
+EVAL-app = "pfsense:unbound"

--- a/default/tags.conf
+++ b/default/tags.conf
@@ -6,3 +6,8 @@ network = enabled
 authentication = enabled
 network = enabled
 vpn = enabled
+
+[eventtype=pfsense_unbound]
+network = enabled
+resolution = enabled
+dns = enabled


### PR DESCRIPTION
this is a working pass at fixing #5 (at least for Pfsense version 2.3.4

note requires log verbosity of 3 or higher in unbound config to see the relevant log lines to extract data

unbound creates far more log lines that are potentially useful to someone wishing to perform analytics in splunk